### PR TITLE
Fix: Ensure X (Twitter) icon displays correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
             
             <div class="flex flex-wrap justify-center gap-6">
                 <a href="https://x.com/Lifelong_Earner" target="_blank" class="social-icon bg-white bg-opacity-20 backdrop-filter backdrop-blur-lg rounded-full w-16 h-16 flex items-center justify-center text-white text-2xl hover:bg-opacity-30">
-                    <i class="fab fa-x-twitter"></i>
+                    <i class="fab fa-x-twitter" style="font-family: 'Font Awesome 6 Brands', 'Font Awesome 6 Free'; font-weight: 400; display: inline-block;"></i>
                 </a>
                 <a href="https://www.youtube.com/watch?v=kpF5N6JkiHU" target="_blank" class="social-icon bg-white bg-opacity-20 backdrop-filter backdrop-blur-lg rounded-full w-16 h-16 flex items-center justify-center text-white text-2xl hover:bg-opacity-30">
                     <i class="fab fa-youtube"></i>
@@ -782,7 +782,7 @@
                     </p>
                     <div class="flex space-x-4">
                         <a href="https://x.com/Lifelong_Earner" target="_blank" class="social-icon text-gray-400 hover:text-white">
-                            <i class="fab fa-x-twitter text-xl"></i>
+                            <i class="fab fa-x-twitter text-xl" style="font-family: 'Font Awesome 6 Brands', 'Font Awesome 6 Free'; font-weight: 400; display: inline-block;"></i>
                         </a>
                         <a href="https://www.youtube.com/watch?v=kpF5N6JkiHU" target="_blank" class="social-icon text-gray-400 hover:text-white">
                             <i class="fab fa-youtube text-xl"></i>


### PR DESCRIPTION
The X (formerly Twitter) icon in the "Connect with us" section and the footer was not displaying. This was likely due to CSS conflicts overriding the default Font Awesome styles.

This commit applies specific inline styles to the `fa-x-twitter` icon elements to ensure they render correctly. The styles explicitly set `font-family`, `font-weight`, and `display` properties crucial for Font Awesome brand icons.

- I verified Font Awesome integration and icon class (`fa-x-twitter`).
- I confirmed the icon renders correctly in an isolated test environment.
- I applied inline styles to the icon elements in `index.html`.
- I verified the fix and cleaned up temporary test files.